### PR TITLE
Only show popup in map view

### DIFF
--- a/ABookCaseOrbitalReferenceSystem/ABookCaseOrbitalReferenceSystem.cs
+++ b/ABookCaseOrbitalReferenceSystem/ABookCaseOrbitalReferenceSystem.cs
@@ -33,7 +33,7 @@ namespace ABCORS
 
         private void Update()
         {
-            _mouseOver = MouseOverOrbit();
+            _mouseOver = MapView.MapIsEnabled && MouseOverOrbit();
 
             if (!_mouseOver)
                 return;


### PR DESCRIPTION
The popup can be triggered by mousing around in the flight scene:
![](https://user-images.githubusercontent.com/758097/83570421-4ac53580-a526-11ea-8e07-e503744d3fbf.jpg)

I'm not sure if this is an intended feature or a bug. I find it a bit irritating :)
This patch restricts the popup to the map view.
